### PR TITLE
Fix migrations

### DIFF
--- a/migrations/03-job-tag-many-association.js
+++ b/migrations/03-job-tag-many-association.js
@@ -4,24 +4,23 @@ module.exports = async function(migration) {
   const job = await upsertContentType(migration, 'job')
   const tag = await upsertContentType(migration, 'tag')
 
-  const tagsField = await upsertField(job, 'tags')
-  const jobsField = await upsertField(tag, 'jobs')
-
-  tagsField
-    .type('Array')
-    .name('Tags')
-    .items({
+  await upsertField(job, 'tags', {
+    type: 'Array',
+    name: 'Tags',
+    items: {
       type: 'Link',
       linkType: 'Entry',
       validations: [{ linkContentType: ['tag'] }],
-    })
+    },
+  })
 
-  jobsField
-    .type('Array')
-    .name('Jobs')
-    .items({
+  await upsertField(tag, 'jobs', {
+    type: 'Array',
+    name: 'Jobs',
+    items: {
       type: 'Link',
       linkType: 'Entry',
       validations: [{ linkContentType: ['job'] }],
-    })
+    },
+  })
 }

--- a/migrations/utils.js
+++ b/migrations/utils.js
@@ -25,15 +25,15 @@ module.exports = {
     }
   },
 
-  async upsertField(contentType, fieldId) {
+  async upsertField(contentType, fieldId, options = {}) {
     try {
       const ct = await getContentType(contentType.id)
       if (ct.fields.some((fld) => fld.id === fieldId)) {
-        return contentType.editField(fieldId)
+        return contentType.editField(fieldId, options)
       }
       throw new Error(`Field ${fieldId} does not exist.`)
     } catch {
-      return contentType.createField(fieldId)
+      return contentType.createField(fieldId, options)
     }
   },
 }

--- a/migrations/utils.js
+++ b/migrations/utils.js
@@ -15,6 +15,9 @@ const getContentType = async function(contentTypeId) {
   return environment.getContentType(contentTypeId)
 }
 
+const hasFieldInContentType = (ct, fieldId) =>
+  ct.fields.some((fld) => fld.id === fieldId)
+
 module.exports = {
   async upsertContentType(migration, contentTypeId) {
     try {
@@ -28,7 +31,7 @@ module.exports = {
   async upsertField(contentType, fieldId, options = {}) {
     try {
       const ct = await getContentType(contentType.id)
-      if (ct.fields.some((fld) => fld.id === fieldId)) {
+      if (hasFieldInContentType(ct, fieldId)) {
         return contentType.editField(fieldId, options)
       }
       throw new Error(`Field ${fieldId} does not exist.`)


### PR DESCRIPTION
Fix association migration.
The `upsertField` was creating/editing the field before setting the `type`, `name` and `items` values.
Now, `upsertField` will receive a third parameter `options` with theses values.

Issue: #9 